### PR TITLE
Model overrides

### DIFF
--- a/tests/test_arcs.py
+++ b/tests/test_arcs.py
@@ -313,6 +313,18 @@ class MyTestClass(TestCase):
         d1["phosphate"] = d1["phosphate"] * (1 - 0.005 * 1.005 ** (10 - 20))
         self.assertDictAlmostEqual(d1, arc1.queue[0])
 
+    def test_overrides_simple_arc(self):
+        model = self.get_simple_model1()
+        arc1 = model[5]
+        arc1.apply_overrides({"capacity": 3.1, "preference": 0.65})
+        self.assertEqual(3.1, arc1.capacity)
+        self.assertEqual(0.65, arc1.preference)
+
+        # Test incorrect label
+        overrides = {"capacity": 3.1, "preferenceasd": 0.65}
+        arc1.apply_overrides(overrides)
+        self.assertEqual({"preferenceasd": 0.65}, overrides)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/wsimod/arcs/arcs.py
+++ b/wsimod/arcs/arcs.py
@@ -90,7 +90,10 @@ class Arc(WSIObj):
         Args:
             overrides (dict, optional): Dictionary of overrides. Defaults to {}.
         """
-        pass
+        self.capacity = overrides.pop("capacity", self.capacity)
+        self.preference = overrides.pop("preference", self.preference)
+        if len(overrides) > 0:
+            print(f"No override behaviour defined for: {overrides.keys()}")
 
     def arc_mass_balance(self):
         """Checks mass balance for inflows/outflows/storage change in an arc.

--- a/wsimod/nodes/storage.py
+++ b/wsimod/nodes/storage.py
@@ -94,6 +94,10 @@ class Storage(Node):
         if "datum" in overrides.keys():
             self.datum = overrides["datum"]
         if "decays" in overrides.keys():
+            if self.decays is None:
+                raise ValueError(
+                    "Attempting to override decays on a node initialised without decays"
+                )
             self.decays.update(overrides["decays"])
         # apply tank overrides
         self.tank.apply_overrides(overrides)


### PR DESCRIPTION
(don't be scared about LOC - it's mainly just test formatting)

- `add_overrides` for `model`
- test
- correction in `storage` overrides
- basic `apply_overrides` behaviour for arcs

I branched this from #120 so figured sensible to merge into that - that said, may be easier to put this into `main` and update #120 from `main`... not sure